### PR TITLE
feat:add WaitTask to wait all tasks done

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ func setupConfig(config Config, p *Pool) {
 
 	var goroutines []*Goroutine
 	for i := 0; i < config.Goroutines; i++ {
-		g := NewGoroutine(p.ctx, p.pipe)
+		g := NewGoroutine(p)
 
 		goroutines = append(goroutines, g)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/0x9n0p/pooli
 
 go 1.17
+
+require github.com/go-playground/assert/v2 v2.2.0

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,37 @@
+package pooli_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/0x9n0p/pooli"
+	"github.com/go-playground/assert/v2"
+)
+
+func TestTaskWait(t *testing.T) {
+
+	var doneCount int32
+
+	p := pooli.Open(context.Background(), pooli.Config{
+		Goroutines: 1,
+		Pipe:       make(chan pooli.Task),
+	})
+
+	p.Start()
+
+	for i := 0; i < 1000; i++ {
+		go func(n int) {
+			p.SendTask(pooli.NewTask(func(ctx context.Context) error {
+				atomic.AddInt32(&doneCount, 1)
+
+				return nil
+			}))
+		}(i)
+
+	}
+	p.WaitTask()
+
+	assert.Equal(t, int32(1000), doneCount)
+
+}


### PR DESCRIPTION
we can use atomic.add to log  the  task number we have already sent  when submiting task instead of using waitGroup